### PR TITLE
exclude execute block from allBlocks

### DIFF
--- a/src/blockly-main.ts
+++ b/src/blockly-main.ts
@@ -23,7 +23,7 @@ export var allBlocks;
 
 Blockly.addChangeListener(function(event) {
 	Blockly.Events.disableOrphans(event);
-	allBlocks = workspacePlayground.getAllBlocks();
+	allBlocks = workspacePlayground.getAllBlocks().filter((block) => (block.type !== 'execute'));
 
 	code = Blockly.JavaScript.blockToCode(workspacePlayground.getBlockById('initialBlock')) as string;
 	console.log(code);


### PR DESCRIPTION
#130 
経緯：Playing実行中は全てのブロックを動かせないようにしていた（逆に、実行が終わった瞬間に動かせるようにしていた）。ここで、全てのブロックに実行ブロックも含まれていたため、setDeletable(true)が適応されてしまっていた。