### PR TITLE
プレイ中、ゲームオーバー時のbackボタンは現在のステージセレクト、リザルト時のbackボタンは次のステージセレクトに自動遷移

### DIFF
--- a/src/buttons/back-to-stageselecting-button.ts
+++ b/src/buttons/back-to-stageselecting-button.ts
@@ -5,18 +5,18 @@ import Button from './button';
 export default class BackToStageSelectingButton extends Button {
 	private scene: Scene;
 
-	public constructor(scene: Scene) {
+	public constructor(scene: Scene, stageNum: number) {
 		super(164, 66, scene, 'img/back_button.png', 'img/back_button_hover.png');
 		this.x = 0;
 		this.y = 510;
 
-		this.initButton(scene);
+		this.initButton(scene, stageNum);
 	}
 
-	private initButton(scene: Scene) {
+	private initButton(scene: Scene, stageNum: number) {
 		this.addEventListener('touchstart', () => {
 			console.log('BackToStageSelecting button is pushed!');
-			scene.moveNextScene('StageSelecting');
+			scene.moveNextScene('StageSelecting', stageNum);
 		});
 	}
 }

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -33,7 +33,7 @@ export class SceneManager {
 		if (this.currentScene === 'Top') {
 			if (sceneKind === 'StageSelecting') {
 				this.currentScene = 'StageSelecting';
-				core.replaceScene(new StageSelectingScene(this));
+				core.replaceScene(new StageSelectingScene(this, 0));
 				return;
 			}
 		}
@@ -60,13 +60,13 @@ export class SceneManager {
 
 			if (sceneKind == 'StageSelecting') {
 				this.currentScene = 'StageSelecting';
-				core.replaceScene(new StageSelectingScene(this));
+				core.replaceScene(new StageSelectingScene(this, stageNum));
 				return;
 			}
 
 			if (sceneKind === 'GameOver') {
 				this.currentScene = 'GameOver';
-				core.pushScene(new GameOverScene(this));
+				core.pushScene(new GameOverScene(this, stageNum));
 				return;
 			}
 			if (sceneKind === 'Result') {
@@ -85,7 +85,8 @@ export class SceneManager {
 			if (sceneKind === 'StageSelecting') {
 				this.currentScene = 'StageSelecting';
 				core.popScene();
-				core.replaceScene(new StageSelectingScene(this));
+				console.log(stageNum);
+				core.replaceScene(new StageSelectingScene(this, stageNum));
 				return;
 			}
 		}

--- a/src/scenes/gameover-scene.ts
+++ b/src/scenes/gameover-scene.ts
@@ -8,7 +8,7 @@ export default class GameOverScene extends Scene {
 	private retryButton: RetryButton;
 	private backToStageSelectingButton: BackToStageSelectingButton;
 
-	public constructor(manager: SceneManager) {
+	public constructor(manager: SceneManager, stageNum: number) {
 		super('GameOver', manager);
 
 		const gameOverLabel = new enchant.Sprite(300, 80);
@@ -23,7 +23,7 @@ export default class GameOverScene extends Scene {
 
 		this.retryButton = new RetryButton(42, 400, this);
 
-		this.backToStageSelectingButton = new BackToStageSelectingButton(this);
+		this.backToStageSelectingButton = new BackToStageSelectingButton(this, stageNum);
 
 		this.addChild(gameOverLabel);
 		this.addChild(gameOverReasonLabel);

--- a/src/scenes/playing-scene.ts
+++ b/src/scenes/playing-scene.ts
@@ -23,7 +23,7 @@ export default class PlayingScene extends Scene {
 		this.stageNum = stageNum;
 		this.codeRunner = new CodeRunner(this.world);
 		this.startStopButton = new StartStopButton(this, 42, 400);
-		this.backToStageSelectingButton = new BackToStageSelectingButton(this);
+		this.backToStageSelectingButton = new BackToStageSelectingButton(this, this.stageNum);
 
 		this.initScene();
 
@@ -42,6 +42,7 @@ export default class PlayingScene extends Scene {
 
 	public moveNextScene(nextkind: SceneKind) {
 		const clearStatus = this.world.getClearStatus();
+		console.log(this.stageNum);
 		super.moveNextScene(nextkind, this.stageNum, clearStatus);
 		this.reset();
 	}

--- a/src/scenes/playing-scene.ts
+++ b/src/scenes/playing-scene.ts
@@ -43,7 +43,6 @@ export default class PlayingScene extends Scene {
 
 	public moveNextScene(nextkind: SceneKind) {
 		const clearStatus = this.world.getClearStatus();
-		console.log(this.stageNum);
 		super.moveNextScene(nextkind, this.stageNum, clearStatus);
 		this.reset();
 	}

--- a/src/scenes/result-scene.ts
+++ b/src/scenes/result-scene.ts
@@ -69,7 +69,7 @@ export default class ResultScene extends Scene {
 
 		const retryButton = new RetryButton(42, 400, this);
 
-		const backToStageSelectingButton = new BackToStageSelectingButton(this);
+		const backToStageSelectingButton = new BackToStageSelectingButton(this, stageNum + 1);
 
 		this.addChild(background);
 		this.addChild(gameClearLabel);

--- a/src/scenes/result-scene.ts
+++ b/src/scenes/result-scene.ts
@@ -69,7 +69,8 @@ export default class ResultScene extends Scene {
 
 		const retryButton = new RetryButton(42, 400, this);
 
-		const backToStageSelectingButton = new BackToStageSelectingButton(this, stageNum + 1);
+		let nextStageLabel = Math.min(stageNum + 1, stages.length - 1);
+		const backToStageSelectingButton = new BackToStageSelectingButton(this, nextStageLabel);
 
 		this.addChild(background);
 		this.addChild(gameClearLabel);

--- a/src/scenes/stage-selecting-scene.ts
+++ b/src/scenes/stage-selecting-scene.ts
@@ -58,7 +58,7 @@ export default class StageSelectingScene extends Scene {
 		this.backButton = new BackToTopButton(this);
 		this.stageLabels = new StageLabels(this.manager.getClearSituation(0));
 		this.stageNum = stageNum;
-		this.stageLabels.update(stageNum,this.manager.getClearSituation(stageNum));
+		this.stageLabels.update(stageNum, this.manager.getClearSituation(stageNum));
 
 		this.addChild(background);
 		this.addChild(this.stageLabels);

--- a/src/scenes/stage-selecting-scene.ts
+++ b/src/scenes/stage-selecting-scene.ts
@@ -19,10 +19,10 @@ export default class StageSelectingScene extends Scene {
 	public startButton: StartPlayingButton;
 	public backButton: BackToTopButton;
 
-	public constructor(manager: SceneManager) {
+	public constructor(manager: SceneManager, stageNum: number) {
 		super('StageSelecting', manager);
 
-		this.initScene();
+		this.initScene(stageNum);
 	}
 
 	public upNumber() {
@@ -45,7 +45,7 @@ export default class StageSelectingScene extends Scene {
 		this.stageLabels.update(this.stageNum, this.manager.getClearSituation(this.stageNum));
 	}
 
-	private initScene() {
+	private initScene(stageNum: number) {
 		this.maxStageNum = stages.length - 1;
 		this.stageNum = 0;
 
@@ -57,6 +57,8 @@ export default class StageSelectingScene extends Scene {
 		this.startButton = new StartPlayingButton((core.width - 290) / 2 + 3, 420, this);
 		this.backButton = new BackToTopButton(this);
 		this.stageLabels = new StageLabels(this.manager.getClearSituation(0));
+		this.stageNum = stageNum;
+		this.stageLabels.update(stageNum,this.manager.getClearSituation(stageNum));
 
 		this.addChild(background);
 		this.addChild(this.stageLabels);


### PR DESCRIPTION
#138 
「もどる」ボタンを押した時ステージセレクトのシーンが新しく作られるので、ステージセレクトシーンのコンストラクタにボタンがステージ番号を渡すようにして、コンストラクタ内で現在のステージまで自動遷移するようにしました。
仕様はコミットメッセージの通りです