### PR TITLE
save clear situations in localstorage

### DIFF
--- a/src/buttons/start-continue-button.ts
+++ b/src/buttons/start-continue-button.ts
@@ -12,7 +12,7 @@ export default class StartContinueButton extends Button {
 
 	private initButton(scene: TopScene) {
 		this.addEventListener('touchstart', () => {
-			console.log('StageSelecting');
+			scene.manager.scoreManager.loadClearSituations();
 			scene.moveNextScene('StageSelecting');
 		});
 	}

--- a/src/buttons/start-init-button.ts
+++ b/src/buttons/start-init-button.ts
@@ -12,7 +12,7 @@ export default class StartInitButton extends Button {
 
 	private initButton(scene: TopScene) {
 		this.addEventListener('touchstart', () => {
-			console.log('StageSelecting');
+			scene.manager.scoreManager.resetClearSituations();
 			scene.moveNextScene('StageSelecting');
 		});
 	}

--- a/src/debug-tool.ts
+++ b/src/debug-tool.ts
@@ -9,6 +9,6 @@ export default class DebugTool {
 	}
 
 	public clearAllStages() {
-		stages.forEach((_, idx) => this.scoreManager.updateScore(idx, 1));
+		stages.forEach((_, idx) => this.scoreManager.updateClearSituations(idx, 1));
 	}
 }

--- a/src/scene-manager.ts
+++ b/src/scene-manager.ts
@@ -94,7 +94,7 @@ export class SceneManager {
 	}
 
 	public updateScore(stageNum: number, score: number) {
-		this.scoreManager.updateScore(stageNum, score);
+		this.scoreManager.updateClearSituations(stageNum, score);
 	}
 
 	public getClearSituation(stageNum: number) {

--- a/src/score-manager.ts
+++ b/src/score-manager.ts
@@ -9,21 +9,22 @@ export class ScoreManager {
 
 	public constructor() {
 		this.clearSituations = [];
-		for (var i: number = 0; i < stages.length; i++) {
-			this.clearSituations.push({ isCleared: false, isExcellentCleared: false, score: 0 });
-		}
 	}
 
 	public getClearSituation(stageNum: number) {
 		return this.clearSituations[stageNum];
 	}
 
-	public updateScore(stageNum: number, score: number) {
+	public updateClearSituations(stageNum: number, score: number) {
 		this.clearSituations[stageNum].isCleared = true;
 		if (score >= stages[stageNum].excellentClearNorma) {
 			this.clearSituations[stageNum].isExcellentCleared = true;
 		}
 		this.clearSituations[stageNum].score = Math.max(score, this.clearSituations[stageNum].score);
+
+		if ('localStorage' in window && window.localStorage !== null) {
+			localStorage.setItem('clearSituations', JSON.stringify(this.clearSituations));
+		}
 	}
 
 	public static getBlockCostSum(): number {
@@ -48,6 +49,25 @@ export class ScoreManager {
 
 	public static getStageClearPoint(stageNum) {
 		return stages[stageNum].clearPoint;
+	}
+
+	public resetClearSituations() {
+		this.clearSituations = [];
+		for (var i: number = 0; i < stages.length; i++) {
+			this.clearSituations.push({ isCleared: false, isExcellentCleared: false, score: 0 });
+		}
+		if ('localStorage' in window && window.localStorage) {
+			localStorage.setItem('clearSituations', JSON.stringify(this.clearSituations));
+		}
+	}
+
+	public loadClearSituations() {
+		if ('localStorage' in window && window.localStorage.clearSituations) {
+			this.clearSituations = JSON.parse(localStorage.getItem('clearSituations'));
+		} else {
+			console.error('There are no ClearSituations in LocalStorage!');
+			this.resetClearSituations();
+		}
 	}
 }
 


### PR DESCRIPTION
#139 
LocalStorageにクリア状況を保存するようにした。
「はじめから」を押した時に初期化され、「つづきから」を押した時にLocalStorageにデータが残っていれば読み込むようにした。